### PR TITLE
Pb 57 on the plugin UI it states type legacy user 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,6 @@ bl_info = {
     "author": "OptiTrack",
     "version": (1, 0, 0),
     "blender": (4, 1, 0),
-    "type": "Extenstion",
     "location": "View3D > Toolbar > Motive",
     "description": "Stream Motive asset data into Blender",
     "warning": "",


### PR DESCRIPTION
The actual ticket did not need any changes as this is a Blender internal tag they apply depending on where the plugin came from. However, I did make a change to the Description of the plugin to be a little nicer.